### PR TITLE
Zach/stauses fix

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -21,7 +21,7 @@
     </div>
 
     <!-- Stream and Status Container -->
-    <div class="w-3/5 p-4 bg-white rounded shadow">
+    <div class="w-7/12 p-4 bg-white rounded shadow">
         <img src="{{ url_for('video_feed') }}" alt="Video Stream" class="w-full h-auto" width="640" height="480">
         <div class="mt-2 text-center">
             <p class="text-lg">Stream: <span id="stream_status">{{ stream_status }}</span></p>


### PR DESCRIPTION
## CHANGES

- Replaced offline_bytes with a JPEG-encoded static/temiFace_screen_saver.png in server.py, loaded at startup with error handling, to display as a placeholder when the stream is offline or not started.
- Updated gen_frames() in server.py to serve the filler image and fixed status transitions ("Live", "Offline", "Frozen") based on frame state and freeze detection.
- Adjusted the video container in index.html from max-w-2xl w-full to w-3/5, making it ~60% of the browser width for better scaling on larger monitors while retaining the 640x480 aspect ratio.
- Reduced logging in server.py from DEBUG to INFO level, retaining only key messages: startup events (e.g., filler image load, server start), errors, and stream transitions (e.g., first frame, offline switch, freeze warnings).